### PR TITLE
allow interpolating proc ports in command arguments

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,9 @@ var config = {
     dependsOn: ['<other proc name>', ...],  // optional dependant processes
                                             // differs from async.auto in syntax
     command: 'node',
-    commandArgs: ['index.js', '%port%'],    // %port% is replaced with the port
+    commandArgs: ['index.js', '%port%', '%otherproc.port%'],
+                                            // %port% is replaced with the port
+                                            // %otherproc.port% is replaced with that port
     port: 9999,                             // omit to get a random available port
     logPath: './log/process.log',           // file path to log file for stdio
     spawnOptions: {},                       // options to pass to child_process.spawn

--- a/src/index.coffee
+++ b/src/index.coffee
@@ -22,8 +22,13 @@ convert = (proc) ->
         env: clone(process.env)
       merge spawnOpts, proc.spawnOpts
 
+
+      # move?
       port.findOpen proc.port, (error, availablePort) ->
         return callback(error) if error?
+
+        # has to go here
+
 
         child = spawn(proc.name, proc.command, proc.commandArgs, availablePort, logPath, logHandle, spawnOpts)
 
@@ -57,17 +62,30 @@ defaults = (procName) ->
       callback(null, true)
 
 subprocess = (processConfig, callback) ->
-  config = {}
-  for key in Object.keys(processConfig)
-    config[key] = autoable(key, processConfig[key])
+  try
+    config = {}
+    for key in Object.keys(processConfig)
+      config[key] = autoable(key, processConfig[key])
 
-  async.auto config, (error, procs) ->
-    return callback(error) if error?
-    callback(null, procs)
+    configArray = []
+    for key in Object.keys(processConfig)
+      item = {}
+      item[key] = processConfig[key]
+      configArray.push(item)
+    async.reduce configArray, {}, (result, item, callback) ->
+      # TODO
+      result[]
+
+
+    async.auto config, (error, procs) ->
+      return callback(error) if error?
+      callback(null, procs)
+  catch error
+    callback(error)
 
 subprocess.killAll = (procs) ->
-  for key, value of procs
-    value.rawProcess.kill()
+  for key, proc of procs
+    proc.rawProcess.kill()
 
 module.exports = subprocess
 

--- a/src/spawn.coffee
+++ b/src/spawn.coffee
@@ -35,6 +35,13 @@ interpolatePorts = (args, processName, port) ->
   processPorts["#{processName}.port"] = port
   args.map (arg) ->
     arg = arg.replace '%port%', port
+
+    arg.replace /%([^%]+)%/, (m, key) ->
+      if processPorts[key]
+        processPorts[key]
+      else
+        throw new Error "Invalid placeholder in #{processName}'s argument list: %#{key}%"
+
     for procKey, procPort of processPorts
       arg = arg.replace procKey, procPort
     arg

--- a/src/spawn.coffee
+++ b/src/spawn.coffee
@@ -30,12 +30,17 @@ procNotFoundError = (error, cmd) ->
   error.message = "Unable to find #{cmd}"
   error
 
-interpolatePort = (port) ->
-  (arg) ->
-    arg.replace '%port%', port
+processPorts = {}
+interpolatePorts = (args, processName, port) ->
+  processPorts["#{processName}.port"] = port
+  args.map (arg) ->
+    arg = arg.replace '%port%', port
+    for procKey, procPort of processPorts
+      arg = arg.replace procKey, procPort
+    arg
 
 module.exports = (name, command, commandArgs, port, logPath, logHandle, spawnOpts) ->
-  commandArgs = commandArgs.map(interpolatePort port)
+  commandArgs = interpolatePorts(commandArgs, name, port)
 
   child =
     rawProcess: spawn command, commandArgs, spawnOpts

--- a/test/apps/dep-service.js
+++ b/test/apps/dep-service.js
@@ -1,0 +1,14 @@
+var net = require('net');
+var port = process.argv[2];
+var servicePort = process.argv[3];
+
+var server = net.createServer(function(c) {
+    c.write('hello\r\n');
+    c.pipe(c);
+});
+
+server.listen(port, function() {
+});
+
+console.log(servicePort);
+

--- a/test/tests/proc.test.coffee
+++ b/test/tests/proc.test.coffee
@@ -195,3 +195,14 @@ describe 'sub', ->
             done(testError)
       ), 100
 
+  it 'errors when invalid port key is used', (done) ->
+    config =
+      app:
+        command: 'node'
+        commandArgs: ['test/apps/service.js', '%port%', '%service.port%']
+        logFilePath: 'test/log/key-error.log'
+
+    runSub config, done, (error, processes) ->
+      assert.truthy 'error', error?.stack
+      done()
+

--- a/test/tests/proc.test.coffee
+++ b/test/tests/proc.test.coffee
@@ -163,5 +163,35 @@ describe 'sub', ->
           callback(null, true) # no error
 
     runSub config, done, (error, processes) ->
-      done(error)
+       done(error)
+
+  it 'interpolates other process ports in command arguments', (done) ->
+    config =
+      app:
+        dependsOn: ['service']
+        command: 'node'
+        commandArgs: ['test/apps/dep-service.js', '%port%', '%service.port%']
+        logFilePath: 'test/log/ports-app.log'
+        port: 6500
+
+      service:
+        command: 'node'
+        commandArgs: ['test/apps/service.js', '%port%']
+        logFilePath: 'test/log/ports-service.log'
+
+    runSub config, done, (error, processes) ->
+      return done(error) if error?
+
+      # wait a little bit for the process
+      # to actually write out to the log file;
+      # yes, arbitrary delays are bad
+      setTimeout ( ->
+        processes.app.readLog (error, log) ->
+          return done(error) if error?
+          try
+            assert.include processes.service.port, log
+            done()
+          catch testError
+            done(testError)
+      ), 100
 


### PR DESCRIPTION
You will now be able to use things like `%otherproc.port%` in your command arguments.
