### PR TITLE
update deps

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "subprocess",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "an async.auto for processes",
   "license": "BSD-3-Clause",
   "main": "lib/index.js",
@@ -16,7 +16,7 @@
   },
   "dependencies": {
     "async": "^0.9.0",
-    "lodash": "^3.0.1",
+    "lodash": "^4.17.11",
     "mkdirp": "^0.5.0",
     "portscanner": "^1.0.0"
   }

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   },
   "devDependencies": {
     "assertive": "^1.4.1",
-    "coffee-script": "^1.9.0",
+    "coffee-script": "1.9.3",
     "mocha": "^2.1.0"
   },
   "dependencies": {
@@ -19,5 +19,9 @@
     "lodash": "^4.17.11",
     "mkdirp": "^0.5.0",
     "portscanner": "^1.0.0"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/EndangeredMassa/subprocess"
   }
 }


### PR DESCRIPTION
* fix: bump lodash dep for security issue
* chore: pin coffee version

Primarily to address audit warnings from: https://nodesecurity.io/advisories/577